### PR TITLE
Store sensitive environment variables in a secret.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ The following environment variables may or must be set in order to configure the
      path: "/data/odoo"
    ```
 * **OBK_ODOO_DATA_DIR** - The mount path for the volume *(optional, default /data/odoo)*.  
-* **OBK_SECRET_ODOO_DB_USER** - Your PostgreSQL DB credentials.
-* **OBK_SECRET_ODOO_DB_PASSWORD** - Your PostgreSQL DB credentials.
+* **OBK_SECRET_ODOO_DB_USER** - Your PostgreSQL DB credentials encoded in base64.
+* **OBK_SECRET_ODOO_DB_PASSWORD** - Your PostgreSQL DB credentials encoded in base64.
 * **OBK_ODOO_DB_NAME** - The name of the PostgresSQL DB that will be created *(optional, default postgres-$CI_ENVIRONMENT_SLUG)*.
 * **OBK_ODOO_DB_HOST** - The host where your PostgreSQL is running *(optional, default postgres-service.kube-public.svc.cluster.local)*.
 * **OBK_ODOO_DB_PORT** - The port which your PostgreSQL is accessible at *(optional, default 5432)*.
@@ -103,7 +103,7 @@ GitLab CI exposes many environment variables, see [GitLab CI/CD Variables](https
 
 Passing Your Own Variables
 -----
-All environment variables with prefix `OBK_{SECRET}_ODOO_` are set in the deployed pod's environment (with the prefix removed). Therefore, if you need more environment variable than the one mentioned above to be passed to the pod, simply add the `OBK_ODOO_` prefix (`OBK_SECRET_ODOO_` for sensitive data) to the variable of your deployment environment.
+All environment variables with prefix `OBK_{SECRET_}ODOO_` are set in the deployed pod's environment (with the prefix removed). Therefore, if you need more environment variable than the one mentioned above to be passed to the pod, simply add the `OBK_ODOO_` prefix (`OBK_SECRET_ODOO_` for sensitive data) to the variable of your deployment environment. Take care, secret variables must be base64 encoded !
 
 Use Case Example
 ============

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ The following environment variables may or must be set in order to configure the
      path: "/data/odoo"
    ```
 * **OBK_ODOO_DATA_DIR** - The mount path for the volume *(optional, default /data/odoo)*.  
-* **OBK_SECRET_ODOO_DB_USER** - Your PostgreSQL DB credentials encoded in base64.
-* **OBK_SECRET_ODOO_DB_PASSWORD** - Your PostgreSQL DB credentials encoded in base64.
+* **OBK_SECRET_ODOO_DB_USER** - Your PostgreSQL DB credentials.
+* **OBK_SECRET_ODOO_DB_PASSWORD** - Your PostgreSQL DB credentials.
 * **OBK_ODOO_DB_NAME** - The name of the PostgresSQL DB that will be created *(optional, default postgres-$CI_ENVIRONMENT_SLUG)*.
 * **OBK_ODOO_DB_HOST** - The host where your PostgreSQL is running *(optional, default postgres-service.kube-public.svc.cluster.local)*.
 * **OBK_ODOO_DB_PORT** - The port which your PostgreSQL is accessible at *(optional, default 5432)*.
@@ -103,7 +103,7 @@ GitLab CI exposes many environment variables, see [GitLab CI/CD Variables](https
 
 Passing Your Own Variables
 -----
-All environment variables with prefix `OBK_{SECRET_}ODOO_` are set in the deployed pod's environment (with the prefix removed). Therefore, if you need more environment variable than the one mentioned above to be passed to the pod, simply add the `OBK_ODOO_` prefix (`OBK_SECRET_ODOO_` for sensitive data) to the variable of your deployment environment. Take care, secret variables must be base64 encoded !
+All environment variables with prefix `OBK_{SECRET_}ODOO_` are set in the deployed pod's environment (with the prefix removed). Therefore, if you need more environment variable than the one mentioned above to be passed to the pod, simply add the `OBK_ODOO_` prefix (`OBK_SECRET_ODOO_` for sensitive data) to the variable of your deployment environment.
 
 Use Case Example
 ============

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -34,6 +34,14 @@ spec:
           - name: {{ $k }}
             value: {{ $v | quote }}
           {{- end }}
+          {{- $secret := .Release.Name }}
+          {{- range $k, $v := .Values.secrets.env }}
+          - name: {{ $k }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $secret }}
+                key: {{ $k }}
+          {{- end }}
         ports:
         - name: "{{ .Values.service.name }}"
           containerPort: {{ .Values.service.internalPort }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             value: {{ $v | quote }}
           {{- end }}
           {{- $secret := .Release.Name }}
-          {{- range $k, $v := .Values.secrets.env }}
+          {{- range $k, $v := .Values.secret_env }}
           - name: {{ $k }}
             valueFrom:
               secretKeyRef:

--- a/chart/templates/dropdb.yaml
+++ b/chart/templates/dropdb.yaml
@@ -37,9 +37,9 @@ spec:
         - name: PGPORT
           value: "{{ .Values.application.database_port }}"
         - name: PGUSER
-          value: {{ .Values.application.database_user }}
+          value: {{ .Values.application.database_user | b64dec }}
         - name: PGPASSWORD
-          value: {{ .Values.application.database_password }}
+          value: {{ .Values.application.database_password | b64dec }}
         command: ["/bin/sh"]
         args: ["-c", "dropdb {{ .Values.application.database_name }} && rm -rf {{ .Values.odoodata.datadir }}/filestore/{{ .Values.application.database_name }}"]
       restartPolicy: Never

--- a/chart/templates/dropdb.yaml
+++ b/chart/templates/dropdb.yaml
@@ -37,9 +37,9 @@ spec:
         - name: PGPORT
           value: "{{ .Values.application.database_port }}"
         - name: PGUSER
-          value: {{ .Values.application.database_user | b64dec }}
+          value: {{ .Values.application.database_user }}
         - name: PGPASSWORD
-          value: {{ .Values.application.database_password | b64dec }}
+          value: {{ .Values.application.database_password }}
         command: ["/bin/sh"]
         args: ["-c", "dropdb {{ .Values.application.database_name }} && rm -rf {{ .Values.odoodata.datadir }}/filestore/{{ .Values.application.database_name }}"]
       restartPolicy: Never

--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ template "appname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: {{ .Values.secrets.type }}
+data:
+  {{- range $k, $v := .Values.secrets.env }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}

--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -10,5 +10,5 @@ metadata:
 type: {{ .Values.secrets.type }}
 data:
   {{- range $k, $v := .Values.secret_env }}
-  {{ $k }}: {{ $v | quote }}
+  {{ $k }}: {{ $v | b64enc | quote }}
   {{- end }}

--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -9,6 +9,6 @@ metadata:
     heritage: {{ .Release.Service }}
 type: {{ .Values.secrets.type }}
 data:
-  {{- range $k, $v := .Values.secrets.env }}
+  {{- range $k, $v := .Values.secret_env }}
   {{ $k }}: {{ $v | quote }}
   {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -12,6 +12,8 @@ image:
 application:
   track: stable
   tier: web
+secrets:
+  type: Opaque
 service:
   enabled: true
   name: web

--- a/obk_deploy
+++ b/obk_deploy
@@ -147,7 +147,7 @@ def deploy():
             cmd.append("env.{}={}".format(key[9:], value))
         if key.startswith("OBK_SECRET_ODOO_"):
             cmd.append("--set")
-            cmd.append("env.{}={}".format(key[16:], value))
+            cmd.append("secrets.env.{}={}".format(key[16:], value))
     subprocess.check_call(cmd)
 
     subprocess.check_call(

--- a/obk_deploy
+++ b/obk_deploy
@@ -147,7 +147,7 @@ def deploy():
             cmd.append("env.{}={}".format(key[9:], value))
         if key.startswith("OBK_SECRET_ODOO_"):
             cmd.append("--set")
-            cmd.append("secrets.env.{}={}".format(key[16:], value))
+            cmd.append("secret_env.{}={}".format(key[16:], value))
     subprocess.check_call(cmd)
 
     subprocess.check_call(


### PR DESCRIPTION
OBK_SECRET_ variables were previously dealt with as regular OBK_ variables, thus they ended up in cleartext in the yaml files.
They are now stored in a secret.
Notice that Tiller admin can still see them since they are passed as values.